### PR TITLE
fix(apps.py): Fix Missing Import of Checks in ready method

### DIFF
--- a/system_monitor/apps.py
+++ b/system_monitor/apps.py
@@ -6,3 +6,18 @@ class SystemMonitorConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "system_monitor"
     verbose_name = _("Django System Monitor")
+
+    def ready(self):
+        """This method is called when the application is fully loaded.
+
+        Its main purpose is to perform startup tasks, such as importing
+        and registering system checks for validating the configuration
+        settings of the app. It ensures that all necessary configurations
+        are in place and properly validated when the Django project initializes.
+
+        In this case, it imports the settings checks from the
+        `system_monitor.settings` module to validate the configuration
+        settings.
+
+        """
+        from system_monitor.settings import checks


### PR DESCRIPTION
- Added the missing import statement `from system_monitor.settings import checks` in the `ready` method of the `SystemMonitorConfig` class in `apps.py`.
- This ensures that the application validates its configuration settings during Django's initialization process.

#### Why:
- The missing import prevented the application from performing configuration checks, leading to potential runtime errors or misconfigurations.
- Without validation, critical settings might not be properly checked, reducing the reliability of the application.

Closes #55